### PR TITLE
レジューム機能とアーミングチェックの変更

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -3161,6 +3161,15 @@ namespace MissionPlanner
                 set { bitArray[ConvertValuetoBitmaskOffset((int)MAVLink.MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_LOGGING)] = value; }
             }
 
+            public bool prearm
+            {
+                get => bitArray[
+                    ConvertValuetoBitmaskOffset((int)MAVLink.MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_PREARM_CHECK)];
+                set => bitArray[
+                        ConvertValuetoBitmaskOffset((int)MAVLink.MAV_SYS_STATUS_SENSOR.MAV_SYS_STATUS_PREARM_CHECK)] =
+                    value;
+            }
+
             int ConvertValuetoBitmaskOffset(int input)
             {
                 int offset = 0;

--- a/ExtLibs/Mavlink/Mavlink.cs
+++ b/ExtLibs/Mavlink/Mavlink.cs
@@ -2618,7 +2618,9 @@ ICAROUS_KINEMATIC_BANDS = 42001,
     	///<summary> 0x8000000 Satellite Communication  | </summary>
         [Description("0x8000000 Satellite Communication ")]
         SATCOM=134217728, 
-    
+        ///<summary> 0x10000000 pre-arm check status. Always healthy when armed | </summary>
+        [Description("0x10000000 pre-arm check status. Always healthy when armed")]
+        MAV_SYS_STATUS_PREARM_CHECK = 268435456,
     };
     
     ///<summary>  </summary>

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1306,8 +1306,18 @@ namespace MissionPlanner.GCSViews
                                 if (alt >= rtl_alt * 0.95)
                                 {
                                     // save resume point
-                                    resume_pos.Lat = MainV2.comPort.MAV.cs.lat;
-                                    resume_pos.Lng = MainV2.comPort.MAV.cs.lng;
+                                    if (MainV2.comPort.MAV.param.ContainsKey("RTL_POINT_LAT") && MainV2.comPort.MAV.param.ContainsKey("RTL_POINT_LON"))
+                                    {
+                                        // use the RTL_POINT_LAT and RTL_POINT_LON parameters if they exist
+                                        resume_pos.Lat = (double)MainV2.comPort.MAV.param["RTL_POINT_LAT"] / 10000000;
+                                        resume_pos.Lng = (double)MainV2.comPort.MAV.param["RTL_POINT_LON"] / 10000000;
+                                    }
+                                    else
+                                    {
+                                        // use the current latitude and longitude if the RTL_POINT parameters do not exist
+                                        resume_pos.Lat = MainV2.comPort.MAV.cs.lat;
+                                        resume_pos.Lng = MainV2.comPort.MAV.cs.lng;
+                                    }
                                     resume_pos.Alt = alt;
                                     rtl_yaw = MainV2.comPort.MAV.cs.yaw;
                                     log.Info("rtl yaw value: " + rtl_yaw.ToString("0.00"));

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -4652,7 +4652,14 @@ namespace MissionPlanner
 
                 // update prearm display
                 //MainV2.instance.FlightData.LabelPreArm_ChangeState(!MainV2.comPort.MAV.cs.failsafe);
-                MainV2.instance.FlightData.LabelPreArm_ChangeState(MainV2.comPort.MAV.cs.ekfflags == ekf_status_flags);
+                if (ekf_status_flags != 0)
+                {
+                    MainV2.instance.FlightData.LabelPreArm_ChangeState(MainV2.comPort.MAV.cs.ekfflags == ekf_status_flags);
+                }
+                else
+                {
+                    MainV2.instance.FlightData.LabelPreArm_ChangeState(MainV2.comPort.MAV.cs.sensors_health.prearm);
+                }
 
                 // update flight start button state
                 //MainV2.instance.FlightData.ButtonStart_ChangeState(!(MainV2.comPort.MAV.cs.armed && MainV2.comPort.MAV.cs.mode.ToUpper() == "AUTO"));


### PR DESCRIPTION
以下の2つの修正を含みます。

1. レジュームポイント
　RTL_POINT_LAT、RTL_POINT_LONというパラメータが存在していれば、レジュームポイントの座標に使用する
　存在していなければ、これまでと同様の動作をする（現在の位置をレジュームポイントの座標に使用する）
2. アーミング可能かどうかのチェック
　ekf_status_flagsが設定されていない場合、MAV_SYS_STATUS_PREARM_CHECKによりアーミング可能かどうかを判断する
　https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_PREARM_CHECK
　ekf_status_flagsの値が設定されていればこれまでと同様の動作をする